### PR TITLE
Minor error on lesson 2 about map deleting

### DIFF
--- a/lesson2.slide
+++ b/lesson2.slide
@@ -402,7 +402,7 @@ Outline:
 - get item from a map:
     m3[2]
 - delete from a map
-    delete(m3, "zero")
+    delete(m3, 0)
 
 
 


### PR DESCRIPTION
On lessson 2 the `delete` method example uses an string as key, when the `map` is defined to be of `int` keys