### PR TITLE
issue #108, can't run present. changing go get --> go install as go get is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This assumes that you have go compiler and git installed and on $PATH of your sy
 ```
 git clone https://github.com/RedHatOfficial/GoCourse.git
 cd GoCourse
-go get golang.org/x/tools/cmd/present
+go install golang.org/x/tools/cmd/present
 present
 ```
 


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. Specifically, go get will always act as if the -d flag were enabled.

Cause of this issue, after running the following code 
`go get golang.org/x/tools/cmd/present`

when user tries to execute command `present` it says `present not found`.

Please check the following for more details.

https://go.dev/doc/go-get-install-deprecation