### PR TITLE
Update README.md guide to include latest shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This assumes that you have go compiler and git installed and on $PATH of your sy
 git clone https://github.com/RedHatOfficial/GoCourse.git
 cd GoCourse
 go install golang.org/x/tools/cmd/present
-present
+./presentation.sh
 ```
 
 Afterwards connect with your browser to the mentioned address. To terminate the server use Ctrl+C.


### PR DESCRIPTION
When I wanted to run the presentation locally, I found out the steps don't work. 66409ce70cef4b4e28acd02afac443c8b02c82f4 probably broke them.