### PR TITLE
Add struct embedding example

### DIFF
--- a/lesson2.slide
+++ b/lesson2.slide
@@ -260,6 +260,9 @@ Outline:
 .play lesson2/15_print_user.go /^func main/,/^}/
 
 
+* Struct embedding
+.play lesson2/40_struct_embedding.go
+
 
 * Anonymous structure
 - just declare new variable and specify its type to `struct` _something_

--- a/lesson2/40_struct_embedding.go
+++ b/lesson2/40_struct_embedding.go
@@ -1,0 +1,24 @@
+package main
+
+import "fmt"
+
+type user struct {
+	id   uint32
+	name string
+}
+
+type registeredUser struct {
+	user
+	email string
+}
+
+func main() {
+	registeredUser := registeredUser{
+		user: user{
+			id:   1,
+			name: "Linus",
+		},
+		email: "linus@torvalds.com",
+	}
+	fmt.Println(registeredUser.name, registeredUser.email)
+}


### PR DESCRIPTION
Consider adding struct embedding demonstration to second lesson. It is a great place to emphasize the absence of inheritance in Go when going over this slide.