### PR TITLE
Fix "Step by Step guide to view the slides locally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This assumes that you have go compiler and git installed and on $PATH of your sy
 ```
 git clone https://github.com/RedHatOfficial/GoCourse.git
 cd GoCourse
-go install golang.org/x/tools/cmd/present
+go get golang.org/x/tools/cmd/present
 ./presentation.sh
 ```
 


### PR DESCRIPTION
`go install golang.org/x/tools/cmd/present` is replaced with `go get golang.org/x/tools/cmd/present` as the former command errors out

closes #163