### PR TITLE
Fix markdown link formatting in lesson11.slide

### DIFF
--- a/lesson11.slide
+++ b/lesson11.slide
@@ -45,7 +45,7 @@ https://github.com/RedHatOfficial/GoCourse
 - BSON
 - MessagePack
 
-- https://en.wikipedia.org/wiki/Comparison_of_data-serialization_formats
+- [[https://en.wikipedia.org/wiki/Comparison_of_data-serialization_formats]]
 
 
 


### PR DESCRIPTION
Corrected the formatting of a Wikipedia link to use markdown-style double brackets for consistency with other links in the slide.