### PR TITLE
Fix grammar, replace dead links, and bump go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/RedHatOfficial/GoCourse
 
-go 1.17
+go 1.23

--- a/go_worth_learning.slide
+++ b/go_worth_learning.slide
@@ -13,7 +13,7 @@ Red Hat, Inc.
 There are lots of interesting programming languages that you can learn.
 The question is, should you perfect them all? The answer is no, of course.
 
-So what about the Go language - is it worth try?
+So what about the Go language - is it worth trying?
 
 In this presentation we are going to talk about Go's pros (goroutines,
 channels, GC, type systems) and cons (a language with attributes taken from the
@@ -82,7 +82,7 @@ previous century :)
     
 - and i think that's beautiful
 - not mine, source:
-.link https://goo.gl/Akxjih
+.link https://www.reddit.com/r/ProgrammerHumor/comments/8nwyma/c_is_a_beautiful_language/
 
 * More readable compared to C++
 
@@ -101,7 +101,7 @@ previous century :)
 .link https://www.docker.com/ Docker
 .link https://podman.io/ Podman
 .link https://kubernetes.io/ Kubernetes
-.link https://coreos.com/operators/ Kubernetes Operators
+.link https://operatorframework.io/ Kubernetes Operators
 .link https://min.io/ MinIO
 .link https://nsq.io/ NSQ
 .link https://nats.io/ NATS


### PR DESCRIPTION
## Summary

- **Grammar fix**: "is it worth try?" → "is it worth trying?" in `go_worth_learning.slide` (line 16)
- **Dead link fixes** in `go_worth_learning.slide`:
  - Replaced `goo.gl/Akxjih` short link (URL shortener) with the direct Reddit URL it redirects to
  - Replaced `coreos.com/operators/` (redirects to generic openshift.com) with `operatorframework.io/` — the canonical Operator Framework site
- **go directive bump**: `go 1.17` → `go 1.23` in `go.mod`. Go 1.17 has been EOL since August 2022. The module has no dependencies (empty `go.sum`), so this is zero-risk.

## Verification

- Confirmed each pattern existed via grep before editing
- Verified `goo.gl/Akxjih` redirects to the Reddit thread via `curl -L`
- Verified `coreos.com/operators/` 301-redirects to `openshift.com` (no longer operators-specific)
- Confirmed `go.sum` is empty (no dependency impact)